### PR TITLE
Update Alpine & Python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN set -x \
 	&& find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
 	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf
 
-COPY --from=builder /usr/lib/python3.8/site-packages/ /usr/lib/python3.8/site-packages/
+COPY --from=builder /usr/lib/python3.9/site-packages/ /usr/lib/python3.9/site-packages/
 COPY --from=builder /usr/bin/pylint /usr/bin/pylint
 WORKDIR /data
 ENTRYPOINT ["pylint"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13 as builder
+FROM alpine:3.15 as builder
 
 RUN set -x \
 	&& apk add --no-cache \
@@ -23,7 +23,7 @@ RUN set -x \
 	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf
 
 
-FROM alpine:3.13 as production
+FROM alpine:3.15 as production
 ARG VERSION
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
 #LABEL "org.opencontainers.image.created"=""

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ _test-version:
 				| grep -Eo 'PyCQA/pylint/releases/tag/(pylint-)?(v)?[.0-9]+"' \
 				| grep -Eo "PyCQA/pylint/releases/tag/(pylint-)?(v)?[.0-9]+" \
 				| sed 's/.*tag\///g' \
-				| sort -u \
+				| sort -V \
 				| tail -1 \
 				| grep -Eo '[.0-9]+' \
 		)"; \


### PR DESCRIPTION
Before:
```
$ docker run --rm -i cytopia/pylint:latest --version
pylint 2.9.6
astroid 2.6.6
Python 3.8.10 (default, May  6 2021, 00:05:59)
[GCC 10.2.1 20201203]
```

After:
```
$ docker run --rm -i cytopia/pylint:latest --version
pylint 2.12.2
astroid 2.9.3
Python 3.9.7 (default, Nov 24 2021, 21:15:59)
[GCC 10.3.1 20211027]
```